### PR TITLE
Fin 986

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG  DOCKER_REGISTRY
 ARG  BASE_IMAGE_TAG_DATE
 FROM $DOCKER_REGISTRY/kuali/tomcat7:java8tomcat7-ua-release-$BASE_IMAGE_TAG_DATE
+ARG  KUALICO_TAG
+ENV  KUALICO_TAG=$KUALICO_TAG
 
 RUN groupadd -r kuali && useradd -r -g kuali kualiadm
 

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -104,10 +104,15 @@ tomcat_start () {
     # create new directory to hold the UA changelog files
     mkdir -p $UA_DB_CHANGELOGS_DIR
 
+    # Write KUALICO_TAG to log output. 
+    log "Using KUALICO_TAG: $KUALICO_TAG."
+    echo_time "Using KUALICO_TAG: $KUALICO_TAG."
+    
     # extract files in kfs-core-ua* jar
     # cd $TOMCAT_KFS_CORE_DIR
-    echo "Unzipping $TOMCAT_KFS_DIR/WEB-INF/lib/kfs-core-ua* ..."
-    unzip -q -u $TOMCAT_KFS_DIR/WEB-INF/lib/kfs-core-7.20170511-ua-release* -d $TOMCAT_KFS_CORE_DIR
+    log "Unzipping $TOMCAT_KFS_DIR/WEB-INF/lib/kfs-core-$KUALICO_TAG-ua-release* ..."
+    echo_time "Unzipping $TOMCAT_KFS_DIR/WEB-INF/lib/kfs-core-$KUALICO_TAG-ua-release* ..."
+    unzip -q -u $TOMCAT_KFS_DIR/WEB-INF/lib/kfs-core-$KUALICO_TAG-ua-release* -d $TOMCAT_KFS_CORE_DIR
     echo "Done!"
 
     # copy edu changelog files to changelogs directory


### PR DESCRIPTION
Update to allow for parameterizing KUALICO_TAG from Jenkins to persist thru to the docker image.   Prototype created to test this and to verify change is correct.  The log below shows the container running and outputting value of KUALI_TAG.

Prototype: FIN-9862
LogGroup:  kfs7-devfin9682-application -> kfs.startup.log-kfs7-app1-devfin9682