### PR TITLE
FIN-1246 - Upgrade KFS to log4j v2; cleanup config file cruft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.war
+*.iml
+.idea
 

--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -82,7 +82,6 @@ tomcat_start () {
     cp $TOMCAT_CONFIG_DIRECTORY/server.xml $TOMCAT_BASE_DIR/conf/server.xml
     cp $SECURITY_DIRECTORY/tomcat-users.xml $TOMCAT_BASE_DIR/conf/tomcat-users.xml
     cp $TOMCAT_CONFIG_DIRECTORY/logging.properties $TOMCAT_BASE_DIR/conf/logging.properties
-    cp $TOMCAT_CONFIG_DIRECTORY/log4j.xml $TOMCAT_KFS_WEBINF_DIR/classes/log4j.xml
 
     # copy in New Relic config file
     log "Copying New Relic configuration file."


### PR DESCRIPTION
This deletes a copy command of the old log4j.xml. The new config is now self contained within the published kfs war, so no copying is necessary.
(Also now ignoring intellij files.)